### PR TITLE
specify season_name and climate_region_code when looking up dates of leadtime

### DIFF
--- a/droughtpipeline/load.py
+++ b/droughtpipeline/load.py
@@ -341,7 +341,7 @@ class Load:
                         current_year,
                         current_month,
                         country,
-                        event_name,
+                        season_name,
                         forecast_data, 
                     )
                     if (preseason_event is False) or (
@@ -774,7 +774,8 @@ class Load:
     def __look_up_dates(
             self, 
             country, 
-            event_name, 
+            climate_region_code,
+            season_name,
             current_year,
             current_month,
             lead_time_event='1-month'
@@ -786,11 +787,12 @@ class Load:
             event_name (str): Event name
             lead_time_event (int): Lead time event"""
         datestart, dateend = None, None
-        month_dict = self.settings.get_country_setting(country, "climate_region")[0]["leadtime"]
+        month_dict = self.settings.get_all_leadtime_for_climate_region_code(
+            country, climate_region_code)
         # Iterate in reverse to get the most recent one
         for month in reversed(list(month_dict.keys())):
             for entry in month_dict[month]:
-                if event_name in entry and entry[event_name] == lead_time_event:
+                if season_name in entry and entry[season_name] == lead_time_event:
                     month_num = datetime.strptime(month, "%b").month
                     if month_num > current_month:
                         current_year -= 1
@@ -825,7 +827,7 @@ class Load:
             current_year,
             current_month,
             country, 
-            event_name, 
+            season_name,
             forecast_data
         ):
         '''
@@ -834,7 +836,8 @@ class Load:
         if lead_time == 0:
             datestart, dateend = self.__look_up_dates(
                 country, 
-                event_name, 
+                climate_region_code,
+                season_name, 
                 current_year=current_year,
                 current_month=current_month,
                 lead_time_event='1-month',

--- a/droughtpipeline/settings.py
+++ b/droughtpipeline/settings.py
@@ -128,4 +128,20 @@ class Settings:
         raise ValueError(f"Climate region code {climate_region_code} not found in country {country}")
 
 
+    def get_all_leadtime_for_climate_region_code(self, country: str, climate_region_code: int):
+        # Fetch country setting
+        country_setting = next(
+            (x for x in self.get_setting("countries") if x["name"] == country), None
+        )
+        
+        if not country_setting:
+            raise ValueError(f"Country {country} not found in {self.setting_path}")
+        
+        # Loop through the climate regions for the country
+        for region in country_setting.get('climate_region', []):
+            if region["climate-region-code"] == climate_region_code:
+                return region['leadtime']
+
+        raise ValueError(f"Climate region code {climate_region_code} not found in country {country}")
+
 


### PR DESCRIPTION
This PR is to fix the drought pipeline for specifically for ETH. The country has multiple climate regions and season within one - the new implementation in the most recent PR doesnt cover this. 

The fix is done by specifying season_name and climate_region_code when looking up dates of leadtime.